### PR TITLE
Documentation and formatting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 branch = true
-omit = tests/*
+omit =
+    tests/*
+    */_version.py

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,9 @@
 [flake8]
-ignore = E111, E114, E115, E116, E117, E121, E122, E124, E126, E127, E128, E129, E131, E201, E202, E203, E211, E221, E222, E225, E226, E227, E228, E231, E241, E251, E261, E262, E265, E266, E272, E302, E303, E305, E402, E501, E741, W291, W391, W503, W504
+max-line-length: 90
+extend-ignore =
+    # multiple spaces before operator
+    E221
+    # missing whitespace after ','
+    E231
+    # multiple spaces before keyword
+    E272

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Flake8
         run: |
           pip install flake8
-          flake8 solar tests
+          flake8 textkernel tests
 
   test:
     name: Test textkernel

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,13 +11,27 @@ on:
     - cron: "21 11 * * 0"
 
 jobs:
+  flake8:
+    name: Flake8 textkernel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Flake8
+        run: |
+          pip install flake8
+          flake8 solar tests
+
   test:
     name: Test textkernel
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![GitHub release; latest by date](https://img.shields.io/github/v/release/SETI/rms-textkernel)](https://github.com/SETI/rms-textkernel/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/SETI/rms-textkernel)](https://github.com/SETI/rms-textkernel/releases)
 [![Test Status](https://img.shields.io/github/actions/workflow/status/SETI/rms-textkernel/run-tests.yml?branch=main)](https://github.com/SETI/rms-textkernel/actions)
+[![Documentation Status](https://readthedocs.org/projects/rms-textkernel/badge/?version=latest)](https://rms-textkernel.readthedocs.io/en/latest/?badge=latest)
 [![Code coverage](https://img.shields.io/codecov/c/github/SETI/rms-textkernel/main?logo=codecov)](https://codecov.io/gh/SETI/rms-textkernel)
 <br />
 [![PyPI - Version](https://img.shields.io/pypi/v/rms-textkernel)](https://pypi.org/project/rms-textkernel)
@@ -21,45 +22,71 @@
 [![Number of GitHub stars](https://img.shields.io/github/stars/SETI/rms-textkernel)](https://github.com/SETI/rms-textkernel/stargazers)
 ![GitHub forks](https://img.shields.io/github/forks/SETI/rms-textkernel)
 
-# rms-textkernel
+# Introduction
 
-Supported versions: Python >= 3.8
-
-## PDS Ring-Moon Systems Node, SETI Institute
-## TextKernel Library
-
-This is a set of routines for parsing SPICE text kernels. The simplest use case is as
-follows:
-```
-        import textkernel
-        tkdict = textkernel.from_file('path/to/kernel/file')
-```
-
-The returned dictionary is keyed by all the parameter names (on the left side of an equal
-sign) in the text kernel, and each associated dictionary value is that found on the right
-side. Values are Python ints, floats, strings, datetime objects, or lists of one or more
-of these.
-
-This module implements the complete syntax specification as discussed in the SPICE Kernel
+`textkernel` is a set of routines for parsing SPICE text kernels. This module
+implements the complete syntax specification as discussed in the SPICE Kernel
 Required Reading document, "kernel.req":
-        <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html>
+<https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html>
 
-For convenience, the returned dictionary adds additional, "hierarchical" keys that provide
+`textkernel` is a product of the [PDS Ring-Moon Systems Node](https://pds-rings.seti.org).
+
+# Installation
+
+The `textkernel` module is available via the `rms-textkernel` package on PyPI and can be
+installed with:
+
+    pip install rms-textkernel
+
+# Getting Started
+
+The `textkernel` module provides two functions for reading text kernels:
+
+- `from_text`: Given a string representing the contents of a text kernel, return a
+  dictionary of the values found.
+- `from_file`: Given the path to a text kernel, read the contents and return a dictionary
+  of the values found.
+
+and two functions for manipulating text kernels:
+
+- `continued_value`: Interpret a list of strings as one or more continued strings.
+- `update_dict`: Merge the contents of two text kernel dictionaries, preserving nested
+  values.
+
+Details of each function are available in the [module documentation](https://rms-textkernel.readthedocs.io/en/latest/module.html).
+
+The simplest use case is as follows:
+
+```python
+import textkernel
+tkdict = textkernel.from_file('path/to/kernel/file')
+```
+
+The returned dictionary `tkdict` is keyed by all the parameter names (on the left side of
+an equal sign) in the text kernel, and each associated dictionary value is that found on
+the right side. Values are Python ints, floats, strings, datetime objects, or lists of
+one or more of these.
+
+## Hierarchical Keys
+
+For convenience, the returned dictionary adds additional "hierarchical" keys that provide
 alternative access to the same values. Hierarchical keys are substrings from the original
 parameter name, which return a sub-dictionary keyed by part or all of the remainder of
 that parameter name.
 
 Parameter names with a slash are split apart as if they represented components of a file
 directory tree, so these are equivalent:
-```
-        tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
+
+```python
+tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
 ```
 
 When a body or frame ID is embedded inside a parameter name, it is extracted, converted
 to integer, and used as a piece of the hierarchy, making these equivalent:
-```
-        tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
-        tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
+
+```python
+tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
+tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
 ```
 
 Leading and trailing underscores before and after the embedded numeric ID are stripped
@@ -69,22 +96,42 @@ second key is always the numeric ID.
 
 When the name associated with a body or frame ID is known, that name can be used in the
 place of the integer ID:
-```
-        tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
-        tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
-        tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
+
+```python
+tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
+tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
+tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
 ```
 
 If a frame is uniquely or primarily associated with a particular central body, that
 body's ID can also be used in place of the frame's ID:
-```
-        tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
+
+```python
+tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
 ```
 
 Note that the "BODY" and "FRAME" dictionaries also have an additional entry keyed by "ID",
 which returns the associated integer ID:
+
+```python
+tkdict["FRAME"][623]["ID"] = 623
+tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
 ```
-        tkdict["FRAME"][623]["ID"] = 623
-        tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
-```
+
 This ensures that you can look up a body or frame by name and readily obtain its ID.
+
+# Contributing
+
+Information on contributing to this package can be found in the
+[Contributing Guide](https://github.com/SETI/rms-textkernel/blob/main/CONTRIBUTING.md).
+
+# Links
+
+- [Documentation](https://rms-textkernel.readthedocs.io)
+- [Repository](https://github.com/SETI/rms-textkernel)
+- [Issue tracker](https://github.com/SETI/rms-textkernel/issues)
+- [PyPi](https://pypi.org/project/rms-textkernel)
+
+# Licensing
+
+This code is licensed under the [Apache License v2.0](https://github.com/SETI/rms-textkernel/blob/main/LICENSE).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,31 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'textkernel'
+copyright = '2024, PDS Ring-Moon Systems Node'
+author = 'PDS Ring-Moon Systems Node'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_parser', 'sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,25 @@
+.. solar documentation master file, created by
+   sphinx-quickstart on Fri May 24 12:58:54 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to ``textkernel``'s documentation!
+==========================================
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
+   :start-after: forks/SETI/rms-textkernel)
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   module
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -1,0 +1,7 @@
+``textkernel`` Module
+=====================
+
+.. automodule:: textkernel
+    :member-order: bysource
+    :members:
+    :undoc-members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 coverage
+myst-parser
 numpy
 pyparsing
 pytest
 rms-julian
+sphinx
+sphinxcontrib-napoleon
+sphinx-rtd-theme

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,10 +4,10 @@
 
 import unittest
 
-from tests.test_name_grammar  import *
-from tests.test_value_grammar import *
-from tests.test_from_text     import *
-from tests.test_from_file     import *
+from tests.test_name_grammar  import *  # noqa: F401 F403
+from tests.test_value_grammar import *  # noqa: F401 F403
+from tests.test_from_text     import *  # noqa: F401 F403
+from tests.test_from_file     import *  # noqa: F401 F403
 
 ##########################################################################################
 # Perform unit testing if executed from the command line

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,19 +1,3 @@
 ##########################################################################################
 # textkernel/tests/__init__.py
 ##########################################################################################
-
-import unittest
-
-from tests.test_name_grammar  import *  # noqa: F401 F403
-from tests.test_value_grammar import *  # noqa: F401 F403
-from tests.test_from_text     import *  # noqa: F401 F403
-from tests.test_from_file     import *  # noqa: F401 F403
-
-##########################################################################################
-# Perform unit testing if executed from the command line
-##########################################################################################
-
-if __name__ == '__main__':
-    unittest.main()
-
-##########################################################################################

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -9,100 +9,107 @@ import sys
 
 from textkernel import from_file, update_dict
 
+
 class Test_from_file(unittest.TestCase):
 
-  def test_from_file(self):
+    def test_from_file(self):
 
-    # Parse every test file
-    tkdicts = {}
-    root_dir = pathlib.Path(sys.modules['textkernel'].__file__).parent.parent
-    test_file_dir = root_dir / 'test_files'
-    test_paths = test_file_dir.glob('*')
-    for path in test_paths:
-        tkdicts[path.name] = from_file(path)
+        # Parse every test file
+        tkdicts = {}
+        root_dir = pathlib.Path(sys.modules['textkernel'].__file__).parent.parent
+        test_file_dir = root_dir / 'test_files'
+        test_paths = test_file_dir.glob('*')
+        for path in test_paths:
+            tkdicts[path.name] = from_file(path)
 
-    # An update fills in missing frame names
-    # cas_status_v04.tf, cas_iss_v10.ti
-    cas_status = copy.deepcopy(tkdicts['cas_status_v04.tf'])
-    keys = list(cas_status['FRAME'].keys())
-    self.assertEqual(keys,
-        [-82000, -82001, -82002, -82008, -82009, -82101, -82102, -82103, -82104, -82105,
-         -82106, -82107, -82108, -82350, -82351, -82360, -82361, -82368, -82369, -82370,
-         -82371, -82372, -82378, -82730, -82731, -82732, -82733, -82734, -82740, -82760,
-         -82761, -82762, -82763, -82764, -82765, -82790, -82791, -82792, -82810, -82811,
-         -82812, -82813, -82814, -82820, -82821, -82822, -82840, -82842, -82843, -82844,
-         -82845, -82849, -82890, -82891, -82892, -82893, -82898])
-    self.assertEqual(cas_status['FRAME'][-82898],
-        {'BVT_STATUS': 'INELIGIBLE', 'INSTRUMENT_TYPE': 'RADIATOR', 'ID': -82898,
-         'CENTER': -82})
+        # An update fills in missing frame names
+        # cas_status_v04.tf, cas_iss_v10.ti
+        cas_status = copy.deepcopy(tkdicts['cas_status_v04.tf'])
+        keys = list(cas_status['FRAME'].keys())
+        self.assertEqual(keys,
+                         [-82000, -82001, -82002, -82008, -82009, -82101, -82102, -82103,
+                          -82104, -82105, -82106, -82107, -82108, -82350, -82351, -82360,
+                          -82361, -82368, -82369, -82370, -82371, -82372, -82378, -82730,
+                          -82731, -82732, -82733, -82734, -82740, -82760, -82761, -82762,
+                          -82763, -82764, -82765, -82790, -82791, -82792, -82810, -82811,
+                          -82812, -82813, -82814, -82820, -82821, -82822, -82840, -82842,
+                          -82843, -82844, -82845, -82849, -82890, -82891, -82892, -82893,
+                          -82898])
+        self.assertEqual(cas_status['FRAME'][-82898],
+                         {'BVT_STATUS': 'INELIGIBLE',
+                          'INSTRUMENT_TYPE': 'RADIATOR',
+                          'ID': -82898,
+                          'CENTER': -82})
 
-    tkdict = from_file(test_file_dir / 'cas_iss_v10.ti', tkdict=cas_status)
-    self.assertIs(tkdict, cas_status)
-    self.assertIs(tkdict['FRAME'][-82360], tkdict['FRAME']['CASSINI_ISS_NAC'])
-    self.assertIs(tkdict['FRAME'][-82361], tkdict['FRAME']['CASSINI_ISS_WAC'])
+        tkdict = from_file(test_file_dir / 'cas_iss_v10.ti', tkdict=cas_status)
+        self.assertIs(tkdict, cas_status)
+        self.assertIs(tkdict['FRAME'][-82360], tkdict['FRAME']['CASSINI_ISS_NAC'])
+        self.assertIs(tkdict['FRAME'][-82361], tkdict['FRAME']['CASSINI_ISS_WAC'])
 
-    merged = update_dict(tkdicts['cas_status_v04.tf'],
-                         copy.deepcopy(tkdicts['cas_iss_v10.ti']))
-    self.assertEqual(merged, tkdict)
+        merged = update_dict(tkdicts['cas_status_v04.tf'],
+                             copy.deepcopy(tkdicts['cas_iss_v10.ti']))
+        self.assertEqual(merged, tkdict)
 
-    # Multiple new body name keys inserted into a pre-existing sub-dictionary
-    # new_horizons_295.tsc, nh_v110.tf
-    nh_295 = copy.deepcopy(tkdicts['new_horizons_295.tsc'])
-    body_keys = list(nh_295['BODY'].keys())
-    self.assertEqual(body_keys, [-98, 'NEW HORIZONS'])
-    self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NEW HORIZONS'])
+        # Multiple new body name keys inserted into a pre-existing sub-dictionary
+        # new_horizons_295.tsc, nh_v110.tf
+        nh_295 = copy.deepcopy(tkdicts['new_horizons_295.tsc'])
+        body_keys = list(nh_295['BODY'].keys())
+        self.assertEqual(body_keys, [-98, 'NEW HORIZONS'])
+        self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NEW HORIZONS'])
 
-    tkdict = from_file(test_file_dir / 'nh_v110.tf', tkdict=nh_295)
-    self.assertIs(nh_295, tkdict)
-    self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NEW_HORIZONS'])
-    self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NH'])
-    self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NH_SPACECRAFT'])
+        tkdict = from_file(test_file_dir / 'nh_v110.tf', tkdict=nh_295)
+        self.assertIs(nh_295, tkdict)
+        self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NEW_HORIZONS'])
+        self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NH'])
+        self.assertIs(nh_295['BODY'][-98], nh_295['BODY']['NH_SPACECRAFT'])
 
-    merged = update_dict(tkdicts['new_horizons_295.tsc'],
-                         copy.deepcopy(tkdicts['nh_v110.tf']))
-    self.assertEqual(merged, tkdict)
+        merged = update_dict(tkdicts['new_horizons_295.tsc'],
+                             copy.deepcopy(tkdicts['nh_v110.tf']))
+        self.assertEqual(merged, tkdict)
 
-    # Body name inferred from frame name
-    # cas_rocks_v18.tf
-    tkdict = tkdicts['cas_rocks_v18.tf']
-    self.assertIn('BODY', tkdict)
-    self.assertIs(tkdict['BODY'][619], tkdict['BODY']['YMIR'])
-    self.assertEqual(tkdict['BODY'][619], {'ID': 619, 'NAME': 'YMIR'})
-    self.assertIs(tkdict['FRAME'][619], tkdict['FRAME']['IAU_YMIR'])
+        # Body name inferred from frame name
+        # cas_rocks_v18.tf
+        tkdict = tkdicts['cas_rocks_v18.tf']
+        self.assertIn('BODY', tkdict)
+        self.assertIs(tkdict['BODY'][619], tkdict['BODY']['YMIR'])
+        self.assertEqual(tkdict['BODY'][619], {'ID': 619, 'NAME': 'YMIR'})
+        self.assertIs(tkdict['FRAME'][619], tkdict['FRAME']['IAU_YMIR'])
 
-    # TKFRAME_<name>_* identifications
-    # earth_topo_050714.tf
-    tkdict = tkdicts['earth_topo_050714.tf']
-    self.assertIs(tkdict['TKFRAME']['DSS-12_TOPO'], tkdict['TKFRAME'][1399012])
-    self.assertIs(tkdict['FRAME']['DSS-12_TOPO'], tkdict['FRAME'][1399012])
+        # TKFRAME_<name>_* identifications
+        # earth_topo_050714.tf
+        tkdict = tkdicts['earth_topo_050714.tf']
+        self.assertIs(tkdict['TKFRAME']['DSS-12_TOPO'], tkdict['TKFRAME'][1399012])
+        self.assertIs(tkdict['FRAME']['DSS-12_TOPO'], tkdict['FRAME'][1399012])
 
-    self.assertIs(tkdict['BODY']['DSS-12'], tkdict['BODY'][399012])
-    self.assertEqual(tkdict['BODY'][399012], {'ID': 399012, 'NAME': 'DSS-12'})
+        self.assertIs(tkdict['BODY']['DSS-12'], tkdict['BODY'][399012])
+        self.assertEqual(tkdict['BODY'][399012], {'ID': 399012, 'NAME': 'DSS-12'})
 
-    # Order of merges shouldn't matter (except in TEXT_KERNEL_ID)
-    answer = copy.deepcopy(tkdicts['cas_status_v04.tf'])
-    answer = update_dict(answer, copy.deepcopy(tkdicts['cas_v40.tf']))
-    answer = update_dict(answer, copy.deepcopy(tkdicts['cas_iss_v10.ti']))
-    answer['TEXT_KERNEL_ID'] = set(answer['TEXT_KERNEL_ID'])
+        # Order of merges shouldn't matter (except in TEXT_KERNEL_ID)
+        answer = copy.deepcopy(tkdicts['cas_status_v04.tf'])
+        answer = update_dict(answer, copy.deepcopy(tkdicts['cas_v40.tf']))
+        answer = update_dict(answer, copy.deepcopy(tkdicts['cas_iss_v10.ti']))
+        answer['TEXT_KERNEL_ID'] = set(answer['TEXT_KERNEL_ID'])
 
-    keys = ['cas_status_v04.tf', 'cas_v40.tf', 'cas_iss_v10.ti']
-    orders = [(0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0)]
+        keys = ['cas_status_v04.tf', 'cas_v40.tf', 'cas_iss_v10.ti']
+        orders = [(0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0)]
 
-    for i,j,k in orders:
-        test = from_file(test_file_dir / keys[i])
-        test = from_file(test_file_dir / keys[j], tkdict=test)
-        test = from_file(test_file_dir / keys[k], tkdict=test)
-        test['TEXT_KERNEL_ID'] = set(test['TEXT_KERNEL_ID'])
-        self.assertEqual(test, answer)
+        for i,j,k in orders:
+            test = from_file(test_file_dir / keys[i])
+            test = from_file(test_file_dir / keys[j], tkdict=test)
+            test = from_file(test_file_dir / keys[k], tkdict=test)
+            test['TEXT_KERNEL_ID'] = set(test['TEXT_KERNEL_ID'])
+            self.assertEqual(test, answer)
 
-    # "INS" identifier checks
-    # juno_jiram_v00.ti
-    tkdict = tkdicts['juno_jiram_v00.ti']
-    self.assertIs(tkdict['INS'][-61420], tkdict['INS']['JUNO_JIRAM_S'])
-    self.assertIs(tkdict['FRAME'][-61420], tkdict['FRAME']['JUNO_JIRAM_S'])
-    self.assertEqual(tkdict['FRAME'][-61420], {'ID': -61420, 'NAME': 'JUNO_JIRAM_S',
-                                               'CENTER': -61})
-    self.assertNotIn(-61, tkdict['FRAME'])
+        # "INS" identifier checks
+        # juno_jiram_v00.ti
+        tkdict = tkdicts['juno_jiram_v00.ti']
+        self.assertIs(tkdict['INS'][-61420], tkdict['INS']['JUNO_JIRAM_S'])
+        self.assertIs(tkdict['FRAME'][-61420], tkdict['FRAME']['JUNO_JIRAM_S'])
+        self.assertEqual(tkdict['FRAME'][-61420], {'ID': -61420,
+                                                   'NAME': 'JUNO_JIRAM_S',
+                                                   'CENTER': -61})
+        self.assertNotIn(-61, tkdict['FRAME'])
+
 
 ##########################################################################################
 # Perform unit testing if executed from the command line

--- a/tests/test_from_text.py
+++ b/tests/test_from_text.py
@@ -10,209 +10,212 @@ from textkernel import from_text, continued_value
 
 class Test_from_text(unittest.TestCase):
 
-  ##########################################
+    ##########################################
 
-  def test_continued_strings(self):
+    def test_continued_strings(self):
 
-    text = """
-         CONTINUED_STRINGS = ( 'This //  ',
-                               'is //  ',
-                               'just //',
-                               'one long //',
-                               'string.',
-                               'Here''s a second //',
-                               'continued //'
-                               'string.'              )
-    """
-    d = from_text(text, contin='//', commented=False)
-    self.assertEqual(d, {'CONTINUED_STRINGS': [
-                            'This is just one long string.',
-                            "Here's a second continued string."]})
-
-    parts = text.split('\n')
-    d = from_text(parts, contin='//', commented=False)
-    self.assertEqual(d, {'CONTINUED_STRINGS': [
-                            'This is just one long string.',
-                            "Here's a second continued string."]})
-
-
-    # Collapse one-element list to a string
-    d = from_text("""
-         CONTINUED_STRINGS = ( 'This //  ',
-                               'is //  ',
-                               'just //',
-                               'one long //',
-                               'string.' )
-          """, contin='//', commented=False)
-    self.assertEqual(d, {'CONTINUED_STRINGS':  'This is just one long string.'})
-
-    # No continuation specified
-    d = from_text("""
-         CONTINUED_STRINGS = ( 'This //  ',
-                               'is //  ',
-                               'just //',
-                               'one long //',
-                               'string.' )
-          """, commented=False)
-    self.assertEqual(d, {'CONTINUED_STRINGS': ['This //  ', 'is //  ', 'just //',
-                                               'one long //', 'string.']})
-
-    # "+" is the default sequence for metakernels
-    d = from_text("""
-        KERNELS_TO_LOAD = (
-        'sat164.+',
-        'b+    '
-        'sp',
-        'naif0012.tls'  )
-    """, commented=False)
-    self.assertEqual(d, {'KERNELS_TO_LOAD': ['sat164.bsp', 'naif0012.tls']})
-
-    # Different continuations
-    d = from_text("""
-        KERNELS_TO_LOAD = (
-        'sat164.+',
-        'b+    '
-        'sp',
-        'naif0012.tls'  )
-         CONTINUED_STRINGS = ( 'This //  ',
-                               'is //  ',
-                               'just //',
-                               'one long //',
-                               'string.',
-                               'Here''s a second //',
-                               'continued //'
-                               'string.'              )
-          """, contin='//', commented=False)
-    self.assertEqual(d, {'KERNELS_TO_LOAD': ['sat164.+', 'b+    ', 'sp', 'naif0012.tls'],
-                         'CONTINUED_STRINGS': ['This is just one long string.',
-                          "Here's a second continued string."]})
-    self.assertEqual(continued_value(d['KERNELS_TO_LOAD'], '+'),
-                     ['sat164.bsp', 'naif0012.tls'])
-
-  ##########################################
-
-  def test_continued_value(self):
-
-    val = ['sat164.+', 'b+    ', 'sp', 'naif0012.tls']
-    self.assertEqual(continued_value(val, '+'), ['sat164.bsp', 'naif0012.tls'])
-
-    val = ['sat164.+', 'b+    ', 'sp+', 77]
-    self.assertEqual(continued_value(val, '+'), ['sat164.bsp+', 77])
-
-    val = ['sat164.+', 'b+    ', 'sp']
-    self.assertEqual(continued_value(val, '+'), 'sat164.bsp')
-
-    val = ['sat164.+', 'b+    ', 'sp+']
-    self.assertEqual(continued_value(val, '+'), 'sat164.bsp+')
-
-    val = ['sat164. CONTINUATION!', 'b CONTINUATION!    ', 'sp CONTINUATION! ']
-    self.assertEqual(continued_value(val, ' CONTINUATION!'), 'sat164.bsp CONTINUATION! ')
-
-    val = ['sat164.bsp', 'naif0012.tls']
-    self.assertIs(continued_value(val, '+'), val)
-
-    val = ['sat164.bsp']    # no change, so no collapse
-    self.assertIs(continued_value(val, '+'), val)
-
-    val = ['sat164.bsp+']
-    self.assertIs(continued_value(val, '+'), val)
-
-    val = 'sat164.bsp+'
-    self.assertIs(continued_value(val, '+'), val)
-
-    self.assertEqual(continued_value(777, '+'), 777)
-    self.assertIsInstance(continued_value(777, '+'), int)
-
-    self.assertEqual(continued_value(777., '+'), 777.)
-    self.assertIsInstance(continued_value(777., '+'), float)
-
-    val = [1, 2, 3.]
-    self.assertIs(continued_value(val, '+'), val)
-
-  ##########################################
-
-  def test_plus_equal(self):
-
-    d = from_text("""
-        VAL = ( 1 )
-    """, commented=False)
-    self.assertEqual(d['VAL'], 1)
-
-    d = from_text("""
-        VAL += ( 1 )
-    """, commented=False)
-    self.assertEqual(d['VAL'], [1])
-
-    d = from_text("""
-        VAL = 1
-        VAL += (  2)
-    """, commented=False)
-    self.assertEqual(d['VAL'], [1,2])
-
-    d = from_text("""
-        VAL = 1
-        VAL +=   2
-    """, commented=False)
-    self.assertEqual(d['VAL'], [1,2])
-
-    d = from_text("""
-        VAL = 1
-        VAL += (  2 3)
-    """, commented=False)
-    self.assertEqual(d['VAL'], [1,2,3])
-
-    d = from_text("""
-        VAL = (1   2)
-        VAL += 3
-    """, commented=False)
-    self.assertEqual(d['VAL'], [1,2,3])
-
-    # No continuation of separate entries
-    d = from_text("""
-        VAL = 'abc+'
-        VAL += 'def'
-    """, commented=False, contin='+')
-    self.assertEqual(d['VAL'], ['abc+', 'def'])
-
-  ##########################################
-
-  def test_commented(self):
-
-    text = r"""
-
-        Explanatory text about how to use "\begindata" should be ignored,
-        even if it contains "\begindata", as long as it is not on an isolated line.
-
-        So, in other words, this is still text.
-
-        DELTA_T_A       =   32.184
-        K               =    1.657D-3
-        EB              =    1.671D-2
-        M               = (  6.239996D0   1.99096871D-7 )
-
-                \begindata
-
-                FRAME_VG2_CONE_CLOCK     = -32200
-                FRAME_-32200_NAME        = 'VG2_CONE_CLOCK'
-                FRAME_-32200_CLASS       = 4
-                BEGINTEXT = ('Here''s some text containing +',
-                             '\begintext'
-                            )
-
-        \begintext
-
-                IGNORED = 7
-
+        text = """
+            CONTINUED_STRINGS = ( 'This //  ',
+                                  'is //  ',
+                                  'just //',
+                                  'one long //',
+                                  'string.',
+                                  'Here''s a second //',
+                                  'continued //'
+                                  'string.'              )
         """
+        d = from_text(text, contin='//', commented=False)
+        self.assertEqual(d, {'CONTINUED_STRINGS': [
+                                'This is just one long string.',
+                                "Here's a second continued string."]})
 
-    d = from_text(text, commented=True)
-    self.assertIn('FRAME_VG2_CONE_CLOCK', d)
-    self.assertEqual(d['BEGINTEXT'], ['Here\'s some text containing +', r'\begintext'])
-    self.assertNotIn('DELTA_T_A', d)
-    self.assertNotIn('IGNORED', d)
-    self.assertEqual(d['FRAME_-32200_NAME'], 'VG2_CONE_CLOCK')
+        parts = text.split('\n')
+        d = from_text(parts, contin='//', commented=False)
+        self.assertEqual(d, {'CONTINUED_STRINGS': [
+                                'This is just one long string.',
+                                "Here's a second continued string."]})
 
-    self.assertRaises(ParseException, from_text, text, commented=False)
+        # Collapse one-element list to a string
+        d = from_text("""
+            CONTINUED_STRINGS = ( 'This //  ',
+                                  'is //  ',
+                                  'just //',
+                                  'one long //',
+                                  'string.' )
+            """, contin='//', commented=False)
+        self.assertEqual(d, {'CONTINUED_STRINGS':  'This is just one long string.'})
+
+        # No continuation specified
+        d = from_text("""
+            CONTINUED_STRINGS = ( 'This //  ',
+                                  'is //  ',
+                                  'just //',
+                                  'one long //',
+                                  'string.' )
+            """, commented=False)
+        self.assertEqual(d, {'CONTINUED_STRINGS': ['This //  ', 'is //  ', 'just //',
+                                                   'one long //', 'string.']})
+
+        # "+" is the default sequence for metakernels
+        d = from_text("""
+            KERNELS_TO_LOAD = (
+            'sat164.+',
+            'b+    '
+            'sp',
+            'naif0012.tls'  )
+        """, commented=False)
+        self.assertEqual(d, {'KERNELS_TO_LOAD': ['sat164.bsp', 'naif0012.tls']})
+
+        # Different continuations
+        d = from_text("""
+            KERNELS_TO_LOAD = (
+            'sat164.+',
+            'b+    '
+            'sp',
+            'naif0012.tls'  )
+            CONTINUED_STRINGS = ( 'This //  ',
+                                  'is //  ',
+                                  'just //',
+                                  'one long //',
+                                  'string.',
+                                  'Here''s a second //',
+                                  'continued //'
+                                  'string.'              )
+            """, contin='//', commented=False)
+        self.assertEqual(d, {'KERNELS_TO_LOAD': ['sat164.+', 'b+    ', 'sp',
+                                                 'naif0012.tls'],
+                             'CONTINUED_STRINGS': ['This is just one long string.',
+                                                   "Here's a second continued string."]})
+        self.assertEqual(continued_value(d['KERNELS_TO_LOAD'], '+'),
+                         ['sat164.bsp', 'naif0012.tls'])
+
+    ##########################################
+
+    def test_continued_value(self):
+
+        val = ['sat164.+', 'b+    ', 'sp', 'naif0012.tls']
+        self.assertEqual(continued_value(val, '+'), ['sat164.bsp', 'naif0012.tls'])
+
+        val = ['sat164.+', 'b+    ', 'sp+', 77]
+        self.assertEqual(continued_value(val, '+'), ['sat164.bsp+', 77])
+
+        val = ['sat164.+', 'b+    ', 'sp']
+        self.assertEqual(continued_value(val, '+'), 'sat164.bsp')
+
+        val = ['sat164.+', 'b+    ', 'sp+']
+        self.assertEqual(continued_value(val, '+'), 'sat164.bsp+')
+
+        val = ['sat164. CONTINUATION!', 'b CONTINUATION!    ', 'sp CONTINUATION! ']
+        self.assertEqual(continued_value(val, ' CONTINUATION!'),
+                         'sat164.bsp CONTINUATION! ')
+
+        val = ['sat164.bsp', 'naif0012.tls']
+        self.assertIs(continued_value(val, '+'), val)
+
+        val = ['sat164.bsp']    # no change, so no collapse
+        self.assertIs(continued_value(val, '+'), val)
+
+        val = ['sat164.bsp+']
+        self.assertIs(continued_value(val, '+'), val)
+
+        val = 'sat164.bsp+'
+        self.assertIs(continued_value(val, '+'), val)
+
+        self.assertEqual(continued_value(777, '+'), 777)
+        self.assertIsInstance(continued_value(777, '+'), int)
+
+        self.assertEqual(continued_value(777., '+'), 777.)
+        self.assertIsInstance(continued_value(777., '+'), float)
+
+        val = [1, 2, 3.]
+        self.assertIs(continued_value(val, '+'), val)
+
+    ##########################################
+
+    def test_plus_equal(self):
+
+        d = from_text("""
+            VAL = ( 1 )
+        """, commented=False)
+        self.assertEqual(d['VAL'], 1)
+
+        d = from_text("""
+            VAL += ( 1 )
+        """, commented=False)
+        self.assertEqual(d['VAL'], [1])
+
+        d = from_text("""
+            VAL = 1
+            VAL += (  2)
+        """, commented=False)
+        self.assertEqual(d['VAL'], [1,2])
+
+        d = from_text("""
+            VAL = 1
+            VAL +=   2
+        """, commented=False)
+        self.assertEqual(d['VAL'], [1,2])
+
+        d = from_text("""
+            VAL = 1
+            VAL += (  2 3)
+        """, commented=False)
+        self.assertEqual(d['VAL'], [1,2,3])
+
+        d = from_text("""
+            VAL = (1   2)
+            VAL += 3
+        """, commented=False)
+        self.assertEqual(d['VAL'], [1,2,3])
+
+        # No continuation of separate entries
+        d = from_text("""
+            VAL = 'abc+'
+            VAL += 'def'
+        """, commented=False, contin='+')
+        self.assertEqual(d['VAL'], ['abc+', 'def'])
+
+    ##########################################
+
+    def test_commented(self):
+
+        text = r"""
+
+            Explanatory text about how to use "\begindata" should be ignored,
+            even if it contains "\begindata", as long as it is not on an isolated line.
+
+            So, in other words, this is still text.
+
+            DELTA_T_A       =   32.184
+            K               =    1.657D-3
+            EB              =    1.671D-2
+            M               = (  6.239996D0   1.99096871D-7 )
+
+                    \begindata
+
+                    FRAME_VG2_CONE_CLOCK     = -32200
+                    FRAME_-32200_NAME        = 'VG2_CONE_CLOCK'
+                    FRAME_-32200_CLASS       = 4
+                    BEGINTEXT = ('Here''s some text containing +',
+                                 '\begintext'
+                                )
+
+            \begintext
+
+                    IGNORED = 7
+
+            """
+
+        d = from_text(text, commented=True)
+        self.assertIn('FRAME_VG2_CONE_CLOCK', d)
+        self.assertEqual(d['BEGINTEXT'], ['Here\'s some text containing +',
+                                          r'\begintext'])
+        self.assertNotIn('DELTA_T_A', d)
+        self.assertNotIn('IGNORED', d)
+        self.assertEqual(d['FRAME_-32200_NAME'], 'VG2_CONE_CLOCK')
+
+        self.assertRaises(ParseException, from_text, text, commented=False)
+
 
 #########################################################################################
 # Perform unit testing if executed from the command line

--- a/tests/test_name_grammar.py
+++ b/tests/test_name_grammar.py
@@ -10,25 +10,27 @@ from textkernel._NAME_GRAMMAR import _NAME_GRAMMAR
 
 class Test_NAME_GRAMMAR(unittest.TestCase):
 
-  def test_NAME_GRAMMAR(self):
-    p = _NAME_GRAMMAR + StringEnd()
-    func = p.parse_string
+    def test_NAME_GRAMMAR(self):
+        p = _NAME_GRAMMAR + StringEnd()
+        func = p.parse_string
 
-    self.assertEqual(func('BODY610_GM')[0],             ('BODY', 610, 'GM'))
-    self.assertEqual(func('CK_-61113_SCLK')[0],         ('CK', -61113, 'SCLK'))
-    self.assertEqual(func('DELTET/DELTA_T_A')[0],       ['DELTET', 'DELTA_T_A'])
-    self.assertEqual(func('FRAME-82731_TYPE')[0],       ('FRAME', -82731, 'TYPE'))
-    self.assertEqual(func('FRAME_-82731TYPE')[0],       ('FRAME', -82731, 'TYPE'))
-    self.assertEqual(func('INS-61411_FRAME')[0],        ('INS', -61411, 'FRAME'))
-    self.assertEqual(func('INS-82360_F/NUMBER')[0],     ('INS', -82360, 'F/NUMBER'))
-    self.assertEqual(func('KERNELS_TO_LOAD')[0],        'KERNELS_TO_LOAD')
-    self.assertEqual(func('NAIF_BODY_CODE')[0],         'NAIF_BODY_CODE')
-    self.assertEqual(func('OBJECT_399005_FRAME')[0],    ('OBJECT', 399005, 'FRAME'))
-    self.assertEqual(func('SCLK_PART_END_82')[0],       ('SCLK', -82, 'PART_END'))
-    self.assertEqual(func('SCLK01_TIME_SYS_98')[0],     ('SCLK', -98, '01_TIME_SYS'))
-    self.assertEqual(func('TEXT_KERNEL_ID')[0],         'TEXT_KERNEL_ID')
-    self.assertEqual(func('TKFRAME_-82008_SPEC')[0],    ('TKFRAME', -82008, 'SPEC'))
-    self.assertEqual(func('TKFRAME_DSS-14_TOPO_Q')[0],  ('TKFRAME', 'DSS-14_TOPO', 'Q'))
+        self.assertEqual(func('BODY610_GM')[0],             ('BODY', 610, 'GM'))
+        self.assertEqual(func('CK_-61113_SCLK')[0],         ('CK', -61113, 'SCLK'))
+        self.assertEqual(func('DELTET/DELTA_T_A')[0],       ['DELTET', 'DELTA_T_A'])
+        self.assertEqual(func('FRAME-82731_TYPE')[0],       ('FRAME', -82731, 'TYPE'))
+        self.assertEqual(func('FRAME_-82731TYPE')[0],       ('FRAME', -82731, 'TYPE'))
+        self.assertEqual(func('INS-61411_FRAME')[0],        ('INS', -61411, 'FRAME'))
+        self.assertEqual(func('INS-82360_F/NUMBER')[0],     ('INS', -82360, 'F/NUMBER'))
+        self.assertEqual(func('KERNELS_TO_LOAD')[0],        'KERNELS_TO_LOAD')
+        self.assertEqual(func('NAIF_BODY_CODE')[0],         'NAIF_BODY_CODE')
+        self.assertEqual(func('OBJECT_399005_FRAME')[0],    ('OBJECT', 399005, 'FRAME'))
+        self.assertEqual(func('SCLK_PART_END_82')[0],       ('SCLK', -82, 'PART_END'))
+        self.assertEqual(func('SCLK01_TIME_SYS_98')[0],     ('SCLK', -98, '01_TIME_SYS'))
+        self.assertEqual(func('TEXT_KERNEL_ID')[0],         'TEXT_KERNEL_ID')
+        self.assertEqual(func('TKFRAME_-82008_SPEC')[0],    ('TKFRAME', -82008, 'SPEC'))
+        self.assertEqual(func('TKFRAME_DSS-14_TOPO_Q')[0],  ('TKFRAME', 'DSS-14_TOPO',
+                                                             'Q'))
+
 
 ##########################################################################################
 # Perform unit testing if executed from the command line

--- a/tests/test_value_grammar.py
+++ b/tests/test_value_grammar.py
@@ -11,69 +11,71 @@ from textkernel._DATA_GRAMMAR import VALUE, OPT_WHITE
 
 class Test_VALUE_GRAMMAR(unittest.TestCase):
 
-  def test_INT(self):
-    p = VALUE + OPT_WHITE + StringEnd()
-    self.assertEqual(p.parse_string('  1234 ')[0],  1234)
-    self.assertEqual(p.parse_string(' -1234 ')[0], -1234)
-    self.assertEqual(p.parse_string(' +1234 ')[0],  1234)
+    def test_INT(self):
+        p = VALUE + OPT_WHITE + StringEnd()
+        self.assertEqual(p.parse_string('  1234 ')[0],  1234)
+        self.assertEqual(p.parse_string(' -1234 ')[0], -1234)
+        self.assertEqual(p.parse_string(' +1234 ')[0],  1234)
 
-  def test_FLOAT(self):
-    p = VALUE + OPT_WHITE + StringEnd()
-    self.assertEqual(p.parse_string('  1234.      ')[0],  1234.)
-    self.assertEqual(p.parse_string('  12340.e-01 ')[0],  1234.)
-    self.assertEqual(p.parse_string('  12340e-1   ')[0],  1234.)
-    self.assertEqual(p.parse_string('  234.5e+01  ')[0],  2345.)
-    self.assertEqual(p.parse_string('  234.5D1    ')[0],  2345.)
-    self.assertEqual(p.parse_string('  234.5d1    ')[0],  2345.)
-    self.assertEqual(p.parse_string('  234.5E+001 ')[0],  2345.)
-    self.assertEqual(p.parse_string(' +1234.      ')[0],  1234.)
-    self.assertEqual(p.parse_string(' +12340.e-01 ')[0],  1234.)
-    self.assertEqual(p.parse_string(' +12340e-1   ')[0],  1234.)
-    self.assertEqual(p.parse_string(' +234.5e+01  ')[0],  2345.)
-    self.assertEqual(p.parse_string(' +234.5D1    ')[0],  2345.)
-    self.assertEqual(p.parse_string(' +234.5d1    ')[0],  2345.)
-    self.assertEqual(p.parse_string(' +234.5E+001 ')[0],  2345.)
-    self.assertEqual(p.parse_string(' -1234.0     ')[0], -1234.)
-    self.assertEqual(p.parse_string(' -12340.e-01 ')[0], -1234.)
-    self.assertEqual(p.parse_string(' -12340e-1   ')[0], -1234.)
-    self.assertEqual(p.parse_string(' -234.5e+01  ')[0], -2345.)
-    self.assertEqual(p.parse_string(' -234.5D1    ')[0], -2345.)
-    self.assertEqual(p.parse_string(' -234.5d1    ')[0], -2345.)
-    self.assertEqual(p.parse_string(' -234.5E+001 ')[0], -2345.)
+    def test_FLOAT(self):
+        p = VALUE + OPT_WHITE + StringEnd()
+        self.assertEqual(p.parse_string('  1234.      ')[0],  1234.)
+        self.assertEqual(p.parse_string('  12340.e-01 ')[0],  1234.)
+        self.assertEqual(p.parse_string('  12340e-1   ')[0],  1234.)
+        self.assertEqual(p.parse_string('  234.5e+01  ')[0],  2345.)
+        self.assertEqual(p.parse_string('  234.5D1    ')[0],  2345.)
+        self.assertEqual(p.parse_string('  234.5d1    ')[0],  2345.)
+        self.assertEqual(p.parse_string('  234.5E+001 ')[0],  2345.)
+        self.assertEqual(p.parse_string(' +1234.      ')[0],  1234.)
+        self.assertEqual(p.parse_string(' +12340.e-01 ')[0],  1234.)
+        self.assertEqual(p.parse_string(' +12340e-1   ')[0],  1234.)
+        self.assertEqual(p.parse_string(' +234.5e+01  ')[0],  2345.)
+        self.assertEqual(p.parse_string(' +234.5D1    ')[0],  2345.)
+        self.assertEqual(p.parse_string(' +234.5d1    ')[0],  2345.)
+        self.assertEqual(p.parse_string(' +234.5E+001 ')[0],  2345.)
+        self.assertEqual(p.parse_string(' -1234.0     ')[0], -1234.)
+        self.assertEqual(p.parse_string(' -12340.e-01 ')[0], -1234.)
+        self.assertEqual(p.parse_string(' -12340e-1   ')[0], -1234.)
+        self.assertEqual(p.parse_string(' -234.5e+01  ')[0], -2345.)
+        self.assertEqual(p.parse_string(' -234.5D1    ')[0], -2345.)
+        self.assertEqual(p.parse_string(' -234.5d1    ')[0], -2345.)
+        self.assertEqual(p.parse_string(' -234.5E+001 ')[0], -2345.)
 
-    self.assertRaises(ParseException, p.parse_string, '  1234 .  ')
-    self.assertRaises(ParseException, p.parse_string, '- 12340e-1')
-    self.assertRaises(ParseException, p.parse_string, '-12340 e-1')
-    self.assertRaises(ParseException, p.parse_string, '-12340e -1')
-    self.assertRaises(ParseException, p.parse_string, '-12340e- 1')
+        self.assertRaises(ParseException, p.parse_string, '  1234 .  ')
+        self.assertRaises(ParseException, p.parse_string, '- 12340e-1')
+        self.assertRaises(ParseException, p.parse_string, '-12340 e-1')
+        self.assertRaises(ParseException, p.parse_string, '-12340e -1')
+        self.assertRaises(ParseException, p.parse_string, '-12340e- 1')
 
-  def test_STRING(self):
-    p = VALUE + OPT_WHITE + StringEnd()
-    self.assertEqual(p.parse_string(" '  1234 '")[0], "  1234 ")
-    self.assertEqual(p.parse_string("''' 1234 '")[0], "' 1234 ")
-    self.assertEqual(p.parse_string("' 1234 '''")[0], " 1234 '")
-    self.assertEqual(p.parse_string("' 12''34 '")[0], " 12'34 ")
-    self.assertEqual(p.parse_string("''")[0],         "")
-    self.assertEqual(p.parse_string("''''")[0],       "'")
+    def test_STRING(self):
+        p = VALUE + OPT_WHITE + StringEnd()
+        self.assertEqual(p.parse_string(" '  1234 '")[0], "  1234 ")
+        self.assertEqual(p.parse_string("''' 1234 '")[0], "' 1234 ")
+        self.assertEqual(p.parse_string("' 1234 '''")[0], " 1234 '")
+        self.assertEqual(p.parse_string("' 12''34 '")[0], " 12'34 ")
+        self.assertEqual(p.parse_string("''")[0],         "")
+        self.assertEqual(p.parse_string("''''")[0],       "'")
 
-  def test_DATE(self):
-    p = VALUE + OPT_WHITE + StringEnd()
-    self.assertEqual(p.parse_string('@2001-Jan-01')[0], dt.datetime(2001,1,1))
-    self.assertEqual(p.parse_string('@2001-Jan-01:12:34:56.789')[0],
-                     dt.datetime(2001,1,1,12,34,56,789000))
+    def test_DATE(self):
+        p = VALUE + OPT_WHITE + StringEnd()
+        self.assertEqual(p.parse_string('@2001-Jan-01')[0], dt.datetime(2001,1,1))
+        self.assertEqual(p.parse_string('@2001-Jan-01:12:34:56.789')[0],
+                         dt.datetime(2001,1,1,12,34,56,789000))
 
-    self.assertRaises(ParseException, p.parse_string, '@ 2001-Jan-01')
-    self.assertRaises(Exception, p.parse_string, '@2001 -Jan-01')
-    self.assertRaises(Exception, p.parse_string, '@2001- Jan-01')
+        self.assertRaises(ParseException, p.parse_string, '@ 2001-Jan-01')
+        self.assertRaises(Exception, p.parse_string, '@2001 -Jan-01')
+        self.assertRaises(Exception, p.parse_string, '@2001- Jan-01')
 
-  def test_LIST(self):
-    p = VALUE + OPT_WHITE + StringEnd()
-    self.assertEqual(p.parse_string('(1,2,3)')[0],    [1,2,3])
-    self.assertEqual(p.parse_string('(1)')[0],        1)
-    self.assertEqual(p.parse_string('(1,2, \n3)')[0], [1,2,3])
-    self.assertEqual(p.parse_string("('1','2')")[0],  ['1','2'])
-    self.assertEqual(p.parse_string("('1''','2')")[0],["1'","2"])
-    self.assertEqual(p.parse_string('(1, @Jul-4-1776)')[0], [1, dt.datetime(1776,7,4)])
+    def test_LIST(self):
+        p = VALUE + OPT_WHITE + StringEnd()
+        self.assertEqual(p.parse_string('(1,2,3)')[0],    [1,2,3])
+        self.assertEqual(p.parse_string('(1)')[0],        1)
+        self.assertEqual(p.parse_string('(1,2, \n3)')[0], [1,2,3])
+        self.assertEqual(p.parse_string("('1','2')")[0],  ['1','2'])
+        self.assertEqual(p.parse_string("('1''','2')")[0],["1'","2"])
+        self.assertEqual(p.parse_string('(1, @Jul-4-1776)')[0],
+                         [1, dt.datetime(1776,7,4)])
+
 
 ##########################################################################################
 # Perform unit testing if executed from the command line

--- a/textkernel/_DATA_GRAMMAR.py
+++ b/textkernel/_DATA_GRAMMAR.py
@@ -20,6 +20,7 @@ from pyparsing import (CharsNotIn,
                        Word,
                        ZeroOrMore)
 
+
 ##########################################################################################
 # _DATA_GRAMMAR
 #
@@ -38,6 +39,7 @@ OPT_NEWLINE = Suppress(ZeroOrMore(Word(('\r\n'))))
 OPT_WHITE = Suppress(Optional(White(' \t\r\n')))
 OPT_COMMA = OPT_WHITE + Suppress(Optional(Literal(','))) + OPT_WHITE
 
+
 ############################################
 # Integer
 ############################################
@@ -48,21 +50,23 @@ SIGNED_INT   = Combine(Optional(SIGN) + UNSIGNED_INT)
 INT          = SIGNED_INT | UNSIGNED_INT
 INTEGER      = Combine(Optional(SIGN) + UNSIGNED_INT)
 INTEGER.set_name('INTEGER')
-INTEGER.set_parse_action(lambda s,l,t: int(t[0]))
+INTEGER.set_parse_action(lambda s, loc, toks: int(toks[0]))
+
 
 ############################################
 # Floating-point number
 ############################################
 
 EXPONENT = Suppress(oneOf('e E d D')) + INT
-EXPONENT.set_parse_action(lambda s,l,t:'e' + t[0])
+EXPONENT.set_parse_action(lambda s, loc, toks: 'e' + toks[0])
 
 FLOAT_WITH_INT = Combine(INT + '.' + Optional(UNSIGNED_INT) + Optional(EXPONENT))
 FLOAT_WO_INT   = Combine(Optional(SIGN) + '.' + UNSIGNED_INT + Optional(EXPONENT))
 FLOAT_WO_DOT   = Combine(INT + EXPONENT)
 FLOAT          = (FLOAT_WITH_INT | FLOAT_WO_INT | FLOAT_WO_DOT)
 FLOAT.set_name('FLOAT')
-FLOAT.set_parse_action(lambda s,l,t: float(t[0]))
+FLOAT.set_parse_action(lambda s, loc, toks: float(toks[0]))
+
 
 ############################################
 # Character string
@@ -72,41 +76,41 @@ FLOAT.set_parse_action(lambda s,l,t: float(t[0]))
 # each internal "''" to a single "'".
 
 QUOTEQUOTE = Suppress(Literal("''"))
-QUOTEQUOTE.set_parse_action(lambda s, l, t: ["'"])
+QUOTEQUOTE.set_parse_action(lambda s, loc, toks: ["'"])
 
 STRING = Combine(Suppress(Literal("'"))
                  + ZeroOrMore(CharsNotIn("'\n\r") | QUOTEQUOTE)
                  + Suppress(Literal("'")))
 STRING.set_name('STRING')
 
+
 ############################################
 # Date-time (following "@")
 ############################################
 
-def _parse_datetime(s, l, tokens):
+def _parse_datetime(s, loc, tokens):
     """Convert a date expression to a Python datetime object, using the Julian Library's
     string parser.
     """
 
     try:
         (day, sec) = julian.day_sec_from_string(tokens.as_list()[0])
-            # validate=False is required to avoid an infinite recursion when reading the
-            # the leap seconds kernel, because the leap seconds kernel contains date
-            # fields.
     except ParseException:
+        # Provide a more streamlined error message
         raise ParseException('unrecognized time syntax: ' + tokens[0])  # pragma: no cover
-            # provide a more streamlined error message
 
     isec = int(sec)
     micro = int(1e6 * (sec - isec) + 0.5)
 
-    return dt.datetime(2000,1,1) + dt.timedelta(day, isec, micro)
-        # This will not handle leap seconds correctly, but a leap second is unlikely to
-        # appear as a datetime in a SPICE text kenel.
+    # This will not handle leap seconds correctly, but a leap second is unlikely to
+    # appear as a datetime in a SPICE text kenel.
+    return dt.datetime(2000, 1, 1) + dt.timedelta(day, isec, micro)
+
 
 DATE = Combine(Suppress(Literal('@')) + CharsNotIn('@\r\n\t(), '))
 DATE.set_name('DATE')
 DATE.set_parse_action(_parse_datetime)
+
 
 ############################################
 # LIST
@@ -118,10 +122,11 @@ LIST = (Suppress(Literal('(')) + OPT_NEWLINE
         + OneOrMore(SCALAR + OPT_COMMA) + OPT_NEWLINE
         + Suppress(Literal(')')))
 LIST.set_name('LIST')
-LIST.set_parse_action(lambda s,l,t: t[0] if len(t) == 1 else [list(t)])
+LIST.set_parse_action(lambda s, loc, toks: toks[0] if len(toks) == 1 else [list(toks)])
 
 # Anything on the right side of an equal sign
 VALUE = SCALAR | LIST
+
 
 ############################################
 # Variable names
@@ -130,13 +135,14 @@ VALUE = SCALAR | LIST
 EXCLUDED_CHARS = ' ,()=\t\n\r'
 NAME_ = Combine(CharsNotIn(EXCLUDED_CHARS))
 
+
 ############################################
 # Expressions
 ############################################
 
 STATEMENT = NAME_ + oneOf('= +=') + OPT_NEWLINE + VALUE + NEWLINE
 STATEMENT.set_name('STATEMENT')
-STATEMENT.set_parse_action(lambda s,l,t: tuple(t))
+STATEMENT.set_parse_action(lambda s, loc, toks: tuple(toks))
 
 _DATA_GRAMMAR = OneOrMore(NEWLINE | STATEMENT) + StringEnd()
 _DATA_GRAMMAR.set_name('_DATA_GRAMMAR')

--- a/textkernel/_NAME_GRAMMAR.py
+++ b/textkernel/_NAME_GRAMMAR.py
@@ -47,7 +47,7 @@ INDEXED_NAME = (oneOf(['BODY', 'OBJECT', 'FRAME', 'TKFRAME', 'INS', 'CK'])
                 + Suppress(Optional(Literal('_')))
                 + GENERAL_NAME)
 INDEXED_NAME.set_name('INDEXED_NAME')
-INDEXED_NAME.set_parse_action(lambda s,l,t: tuple(t))
+INDEXED_NAME.set_parse_action(lambda s, loc, toks: tuple(toks))
 
 TKFRAME_SUFFIX = oneOf(['ANGLES', 'AXES', 'BORESIGHT', 'MATRIX', 'Q', 'RELATIVE', 'SPEC',
                         'UNITS'])
@@ -59,7 +59,7 @@ TKFRAME_NAME = (Literal('TKFRAME')
                 + Suppress(Literal('_'))
                 + TKFRAME_SUFFIX)
 TKFRAME_NAME.set_name('TKFRAME_NAME')
-TKFRAME_NAME.set_parse_action(lambda s,l,t: tuple(t))
+TKFRAME_NAME.set_parse_action(lambda s, loc, toks: tuple(toks))
 
 CK_NAME = (Literal('SCLK')
            + Suppress(Optional(Literal('_')))
@@ -67,11 +67,12 @@ CK_NAME = (Literal('SCLK')
                                 + Word(alphanums+'_-', min=1, max=1)))
            + Suppress(Literal('_')) + UNSIGNED_INT)
 CK_NAME.set_name('CK_NAME')
-CK_NAME.set_parse_action(lambda s,l,t: (t[0], -int(t[2]), t[1]))    # swap, change sign
+CK_NAME.set_parse_action(lambda s, loc, toks:
+                         (toks[0], -int(toks[2]), toks[1]))  # swap, change sign
 
 SECTION_NAME = Combine(CharsNotIn(EXCLUDED_CHARS + '/'))
 NESTED_NAME = OneOrMore(SECTION_NAME + Suppress(Literal('/'))) + SECTION_NAME
-NESTED_NAME.set_parse_action(lambda s,l,t: [list(t)])
+NESTED_NAME.set_parse_action(lambda s, loc, toks: [list(toks)])
 
 _NAME_GRAMMAR = ((INDEXED_NAME | TKFRAME_NAME | CK_NAME | NESTED_NAME | GENERAL_NAME)
                  + StringEnd())

--- a/textkernel/__init__.py
+++ b/textkernel/__init__.py
@@ -1,57 +1,26 @@
 ##########################################################################################
 # textkernel/__init__.py
 ##########################################################################################
-"""PDS Ring-Moon Systems Node, SETI Institute
-TextKernel Library
-
-This is a set of routines for parsing SPICE text kernels. The simplest use case is as
-follows:
-    import textkernel
-    tkdict = textkernel.from_file('path/to/kernel/file')
-
-The returned dictionary is keyed by all the parameter names (on the left side of an equal
-sign) in the text kernel, and each associated dictionary value is that found on the right
-side. Values are Python ints, floats, strings, datetime objects, or lists of one or more
-of these.
-
-This module implements the complete syntax specification as discussed in the SPICE Kernel
-Required Reading document, "kernel.req".
-  https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
-
-For convenience, the returned dictionary adds additional, "hierarchical" keys that provide
-alternative access to the same values. Hierarchical keys are substrings from the original
-parameter name, which return a sub-dictionary keyed by part or all of the remainder of
-that parameter name.
-
-- Parameter names with a slash are split apart as if they represented components of a file
-  directory tree, so these are equivalent:
-        tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
-
-- When a body or frame ID is embedded inside a parameter name, it is extracted, converted
-  to integer, and used as a piece of the hierarchy, making these equivalent:
-        tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
-        tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
-  Leading and trailing underscores before and after the embedded numeric ID are stripped
-  from the hierarchical keys, as you can see in the examples above. Note also that the
-  components of the parameter name are re-ordered in the second example, so that the
-  second key is always the numeric ID.
-
-- When the name associated with a body or frame ID is known, that name can be used in the
-  place of the integer ID:
-        tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
-        tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
-        tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
-
-- If a frame is uniquely or primarily associated with a particular central body, that
-  body's ID can also be used in place of the frame's ID:
-        tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
-
-Note that the "BODY" and "FRAME" dictionaries also have an additional entry keyed by "ID",
-which returns the associated integer ID:
-        tkdict["FRAME"][623]["ID"] = 623
-        tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
-This ensures that you can look up a body or frame by name and readily obtain its ID.
 """
+This is a set of routines for parsing SPICE text kernels. This module implements the
+complete syntax specification as discussed in the SPICE Kernel Required Reading document,
+"kernel.req": https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
+
+The `textkernel` module provides two functions for reading text kernels:
+
+- `from_text`: Given a string representing the contents of a text kernel, return a
+  dictionary of the values found.
+- `from_file`: Given the path to a text kernel, read the contents and return a dictionary
+  of the values found.
+
+and two functions for manipulating text kernels:
+
+- `continued_value`: Interpret a list of strings as one or more continued strings.
+- `update_dict`: Merge the contents of two text kernel dictionaries, preserving nested
+  values.
+"""
+
+__all__ = ['from_text', 'from_file', 'continued_value', 'update_dict']
 
 import pathlib
 import re
@@ -79,17 +48,18 @@ def from_text(text, tkdict=None, *, commented=True, contin=''):
     Parse a string as the contents of a text kernel and return a dict of values found.
 
     Args:
-        text (str): The contents os a SPICE text kernel. It can be represented as a single
+        text (str): The contents as a SPICE text kernel. It can be represented as a single
             string with embedded newlines or as a list of strings.
         tkdict (dict, optional): An optional starting dictionary. If provided, the new
             content is merged into the one provided; otherwise, a new dictionary is
             returned.
         commented (bool, optional): True if the kernel text contains comments delimited
-            by " \\begintext" and "\\begindata".
+            by `\\\\begintext` and `\\\\begindata`.
         contin (str, optional): Optional sequence of characters indicating that a string
             is "continued", meaning that its value should be concatenated with the
             next string in the list. See the rules for continued strings here:
-                https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
+            https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
+
             If a text kernel uses multiple different continuation sequences (which
             is exceedingly unlikely), you can only specify one sequence here; use
             continued_value() to interpret the values of other continued strings.
@@ -112,29 +82,37 @@ def from_text(text, tkdict=None, *, commented=True, contin=''):
 
         - Parameter names with a slash are split apart as if they represented
           components of a file directory tree, so these are equivalent:
-                tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
+
+          - tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
 
         - When a body or frame ID is embedded inside a parameter name, it is extracted,
           converted to integer, and used as a piece of the hierarchy, making these
           equivalent:
-                tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
-                tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
+
+          - tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
+          - tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
+
           Leading and trailing underscores before and after the embedded numeric ID are
           stripped from the hierarchical keys, as you can see in the examples above.
 
         - When the name associated with a body or frame ID is known, that name can be
           used in the place of the integer ID:
-                tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
-                tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
-                tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
+
+          - tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
+          - tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
+          - tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
 
         - If a frame is associated with a particular central body, the body's ID can also
           be used in place of the frame's ID:
-                tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
-          Note that the "BODY" and "FRAME" dictionaries also have an additional entry
+
+          - tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
+
+        - Note that the "BODY" and "FRAME" dictionaries also have an additional entry
           keyed by "ID", which returns the associated integer ID:
-                tkdict["FRAME"][623]["ID"] = 623
-                tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
+
+          - tkdict["FRAME"][623]["ID"] = 623
+          - tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
+
           This ensures that you can look up a body or frame by name and readily obtain its
           ID.
     """
@@ -334,7 +312,8 @@ def from_file(path, tkdict=None, *, contin=''):
         contin (str, optional): Optional sequence of characters indicating that a string
             is "continued", meaning that its value should be concatenated with the
             next string in the list. See the rules for continued strings here:
-                https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
+            https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
+
             If a text kernel uses multiple different continuation sequences (which
             is exceedingly unlikely), you can only specify one sequence here; use
             continued_value() to interpret the values of other continued strings.
@@ -357,29 +336,37 @@ def from_file(path, tkdict=None, *, contin=''):
 
         - Parameter names with a slash are split apart as if they represented
           components of a file directory tree, so these are equivalent:
-                tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
+
+          - tkdict["DELTET/EB"] == tkdict["DELTET"]["EB"]
 
         - When a body or frame ID is embedded inside a parameter name, it is extracted,
           converted to integer, and used as a piece of the hierarchy, making these
           equivalent:
-                tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
-                tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
+
+          - tkdict["BODY399_POLE_RA"] == tkdict["BODY"][399]["POLE_RA"]
+          - tkdict["SCLK01_MODULI_32"] == tkdict["SCLK"][-32]["01_MODULI"]
+
           Leading and trailing underscores before and after the embedded numeric ID are
           stripped from the hierarchical keys, as you can see in the examples above.
 
         - When the name associated with a body or frame ID is known, that name can be
           used in the place of the integer ID:
-                tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
-                tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
-                tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
+
+          - tkdict["BODY"][399] == tkdict["BODY"]["EARTH"]
+          - tkdict["FRAME"][10013] == tkdict["FRAME"]["IAU_EARTH"]
+          - tkdict["SCLK"][-32] == tkdict["SCLK"]["VOYAGER 2"]
 
         - If a frame is associated with a particular central body, the body's ID can also
           be used in place of the frame's ID:
-                tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
-          Note that the "BODY" and "FRAME" dictionaries also have an additional entry
+
+          - tkdict["FRAME"][399] == tkdict["FRAME"]["IAU_EARTH"]
+
+        - Note that the "BODY" and "FRAME" dictionaries also have an additional entry
           keyed by "ID", which returns the associated integer ID:
-                tkdict["FRAME"][623]["ID"] = 623
-                tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
+
+          - tkdict["FRAME"][623]["ID"] = 623
+          - tkdict["FRAME"]["IAU_SUTTUNGR"]["ID"] = 623
+
           This ensures that you can look up a body or frame by name and readily obtain its
           ID.
     """
@@ -398,18 +385,20 @@ def continued_value(value, contin='+'):
     Use this function if you did not specify the string's continuation sequence when you
     created the dictionary.
 
-    Input:
-        value       a value from a text kernel.
-        contin      sequence of characters indicating that a string is "continued",
-                    meaning that its value should be concatenated with the next string in
-                    the list. See the rules for continued strings here:
-                        https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
+    Args:
+        value (Any): A value from a text kernel.
+        contin (str, optional): A sequence of characters indicating that a string is
+            "continued", meaning that its value should be concatenated with the next
+            string in the list. See the rules for continued strings here:
+            https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Text%20Kernel%20Syntax%20Rules
 
-    Return:         the same value after the continuation sequence has been applied. If
-                    the list now contains only a single value, that string is returned
-                    instead of a list containing the string.
+    Returns:
+        Any: The same value after the continuation sequence has been applied.
 
-    If any other type of value is given as input, that value is returned as is.
+        If the list now contains only a single value, that string is returned
+        instead of a list containing the string.
+
+        If any other type of value is given as input, that value is returned as is.
     """
 
     if not contin:
@@ -447,20 +436,19 @@ def update_dict(tkdict, newdict):
     Values in the new dictionary take precedence.
 
     The returned dictionary is the same as what one would get by reading the first text
-    kernel and then using its return value as the "tkdict" input when reading the second
+    kernel and then using its return value as the `tkdict` input when reading the second
     text kernel.
 
-    Input:
-        tkdict      a text kernel dictionary.
-        newdict     a second text kernel dictionary.
+    Args:
+        tkdict (dict): A text kernel dictionary.
+        newdict (dict): A second text kernel dictionary.
 
-    Return          the input tkdict, updated with the contents of the second dictionary.
+    Returns:
+        dict: The input `tkdict`, updated with the contents of `newdict`.
     """
 
     def alt_dict_keys(d):
-        """A dictionary that maps each dictionary key to its alternative keys including
-        itself.
-        """
+        """Create a dict that maps each key to its alt keys including itself."""
 
         alt_keys = {}
         keys_for_dict_id = {}


### PR DESCRIPTION
- Fixes #2 
- Fixes #4 
- Added documentation build badge to `README.md` and updated `README.md` to new format.
- Changed all docstrings to Google style.
- Added Sphinx-based documentation.
- Removed excess imports in tests directory that were causing all tests to execute twice.
- Made minor formatting changes to eliminate most `flake8` errors. There are only three exceptions left in the `.flake8` configuration file.
- Added `flake8` to automated tests.
