### PR TITLE
Add FCPath support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ import textkernel
 tkdict = textkernel.from_file('path/to/kernel/file')
 ```
 
+(The file path can be any URL accepted by [`FCPath`](https://rms-filecache.readthedocs.io/en/latest/module.html#filecache.file_cache_path.FCPath).)
+
 The returned dictionary `tkdict` is keyed by all the parameter names (on the left side of
 an equal sign) in the text kernel, and each associated dictionary value is that found on
 the right side. Values are Python ints, floats, strings, datetime objects, or lists of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ name = "rms-textkernel"
 dynamic = ["version"]
 description = "Routines for parsing SPICE text kernels"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "pyparsing",
+    "rms-filecache",
     "rms-julian"
 ]
 license = {text = "Apache-2.0"}
@@ -27,7 +28,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ myst-parser
 numpy
 pyparsing
 pytest
+rms-filecache
 rms-julian
 sphinx
 sphinxcontrib-napoleon

--- a/textkernel/__init__.py
+++ b/textkernel/__init__.py
@@ -374,7 +374,7 @@ def from_file(path, tkdict=None, *, contin=''):
           ID.
     """
 
-    text = filecache.FCPath(path).read_text(encoding='latin8')
+    text = filecache.FCPath(path).read_text(encoding='latin1')
     return from_text(text, tkdict=tkdict, commented=True, contin=contin)
 
 

--- a/textkernel/__init__.py
+++ b/textkernel/__init__.py
@@ -23,8 +23,9 @@ and two functions for manipulating text kernels:
 
 __all__ = ['from_text', 'from_file', 'continued_value', 'update_dict']
 
-import pathlib
 import re
+
+import filecache
 
 from textkernel._DATA_GRAMMAR          import _DATA_GRAMMAR
 from textkernel._NAME_GRAMMAR          import _NAME_GRAMMAR
@@ -306,7 +307,8 @@ def from_file(path, tkdict=None, *, contin=''):
     Parse the contents of a text kernel, returning a dict of the values found.
 
     Args:
-        path (str or Path): The path to a kernel file as a string or `pathlib.Path`.
+        path (str or Path or FCPath): The path to a kernel file as a string,
+            `pathlib.Path`, or `filecache.FCPath`.
         tkdict (dict, optional): An optional starting dictionary. If provided, the new
             content is merged into the one provided; otherwise, a new dictionary is
             returned.
@@ -372,7 +374,7 @@ def from_file(path, tkdict=None, *, contin=''):
           ID.
     """
 
-    text = pathlib.Path(path).read_text(encoding='latin8')
+    text = filecache.FCPath(path).read_text(encoding='latin8')
     return from_text(text, tkdict=tkdict, commented=True, contin=contin)
 
 


### PR DESCRIPTION
# Fixed Issues

- Fixes #9 

# Summary of Changes

- Adds support for FCPath to allow reading a remote kernel file.

# Known Problems

- None.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed Python 3.8; minimum Python is now 3.9.
  * Added rms-filecache and rms-julian runtime dependencies.

* **New Features**
  * File path handling expanded to accept additional URL formats and sources.

* **Documentation**
  * Clarified supported input path types and value formats (ints, floats, strings, datetime objects, and lists).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->