### PR TITLE
Replace deprecated pyparsing oneOf with one_of

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "numpy",
-    "pyparsing",
+    "pyparsing>=3.0.0",
     "rms-filecache",
     "rms-julian"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ coverage
 flake8
 myst-parser
 numpy
-pyparsing
+pyparsing>=3.0.0
 pytest
 rms-filecache
 rms-julian

--- a/textkernel/_DATA_GRAMMAR.py
+++ b/textkernel/_DATA_GRAMMAR.py
@@ -9,7 +9,7 @@ from pyparsing import (CharsNotIn,
                        Combine,
                        Literal,
                        nums,
-                       oneOf,
+                       one_of,
                        OneOrMore,
                        Optional,
                        ParseException,
@@ -44,7 +44,7 @@ OPT_COMMA = OPT_WHITE + Suppress(Optional(Literal(','))) + OPT_WHITE
 # Integer
 ############################################
 
-SIGN         = oneOf('+ -')
+SIGN         = one_of('+ -')
 UNSIGNED_INT = Word(nums)
 SIGNED_INT   = Combine(Optional(SIGN) + UNSIGNED_INT)
 INT          = SIGNED_INT | UNSIGNED_INT
@@ -57,7 +57,7 @@ INTEGER.set_parse_action(lambda s, loc, toks: int(toks[0]))
 # Floating-point number
 ############################################
 
-EXPONENT = Suppress(oneOf('e E d D')) + INT
+EXPONENT = Suppress(one_of('e E d D')) + INT
 EXPONENT.set_parse_action(lambda s, loc, toks: 'e' + toks[0])
 
 FLOAT_WITH_INT = Combine(INT + '.' + Optional(UNSIGNED_INT) + Optional(EXPONENT))
@@ -140,7 +140,7 @@ NAME_ = Combine(CharsNotIn(EXCLUDED_CHARS))
 # Expressions
 ############################################
 
-STATEMENT = NAME_ + oneOf('= +=') + OPT_NEWLINE + VALUE + NEWLINE
+STATEMENT = NAME_ + one_of('= +=') + OPT_NEWLINE + VALUE + NEWLINE
 STATEMENT.set_name('STATEMENT')
 STATEMENT.set_parse_action(lambda s, loc, toks: tuple(toks))
 

--- a/textkernel/_NAME_GRAMMAR.py
+++ b/textkernel/_NAME_GRAMMAR.py
@@ -7,7 +7,7 @@ from pyparsing import (alphanums,
                        Combine,
                        Literal,
                        nums,
-                       oneOf,
+                       one_of,
                        OneOrMore,
                        Optional,
                        ParserElement,
@@ -41,7 +41,7 @@ ParserElement.set_default_whitespace_chars('')
 GENERAL_NAME = Combine(CharsNotIn(EXCLUDED_CHARS))
 GENERAL_NAME.set_name('GENERAL_NAME')
 
-INDEXED_NAME = (oneOf(['BODY', 'OBJECT', 'FRAME', 'TKFRAME', 'INS', 'CK'])
+INDEXED_NAME = (one_of(['BODY', 'OBJECT', 'FRAME', 'TKFRAME', 'INS', 'CK'])
                 + Suppress(Optional(Literal('_')))
                 + INTEGER
                 + Suppress(Optional(Literal('_')))
@@ -49,7 +49,7 @@ INDEXED_NAME = (oneOf(['BODY', 'OBJECT', 'FRAME', 'TKFRAME', 'INS', 'CK'])
 INDEXED_NAME.set_name('INDEXED_NAME')
 INDEXED_NAME.set_parse_action(lambda s, loc, toks: tuple(toks))
 
-TKFRAME_SUFFIX = oneOf(['ANGLES', 'AXES', 'BORESIGHT', 'MATRIX', 'Q', 'RELATIVE', 'SPEC',
+TKFRAME_SUFFIX = one_of(['ANGLES', 'AXES', 'BORESIGHT', 'MATRIX', 'Q', 'RELATIVE', 'SPEC',
                         'UNITS'])
 _TKFRAME_SUFFIX = Suppress(Literal('_')) + TKFRAME_SUFFIX
 TKFRAME_NAME = (Literal('TKFRAME')


### PR DESCRIPTION
## Summary

- Fixes #11
- Replaces all 5 uses of the deprecated `oneOf` with `one_of` in `_DATA_GRAMMAR.py` and `_NAME_GRAMMAR.py`
- Eliminates `PyparsingDeprecationWarning: 'oneOf' deprecated - use 'one_of'` on recent pyparsing versions

## Test plan

- [x] All 11 existing tests pass (`pytest tests/ -v`)
- [x] Ran with `-W error::DeprecationWarning` to confirm no deprecation warnings remain
- [x] Updated venv packages to latest versions (pyparsing 3.3.2, pytest 9.0.3, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal grammar parsing components to use current library APIs across data and name parsing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->